### PR TITLE
Create merkle tree from Hasher chunks

### DIFF
--- a/example_static_test.go
+++ b/example_static_test.go
@@ -49,7 +49,7 @@ func TestEncodeStaticObject(t *testing.T) {
 	}
 }
 
-func TestTreeerSymmetricObject(t *testing.T) {
+func TestTreererSymmetricObject(t *testing.T) {
 	withdrawal := &Withdrawal{
 		Index:     11,
 		Validator: 12,
@@ -63,5 +63,4 @@ func TestTreeerSymmetricObject(t *testing.T) {
 	if treeNode.Value != hashNode {
 		t.Errorf("Tree hash mismatch.\nGot:  %#x\nWant: %#x", treeNode.Value, hashNode)
 	}
-	panic("done")
 }

--- a/ssz.go
+++ b/ssz.go
@@ -266,7 +266,6 @@ func TreeSequential(obj Object) *TreeNode {
 	}
 
 	return codec.tre.createTree()[1]
-	//return codec.tre.nodes[len(codec.tre.nodes)-2]
 }
 
 // TreeConcurrent computes the SSZ Merkle tree of the object on a multiple threads.

--- a/ssz.go
+++ b/ssz.go
@@ -265,12 +265,8 @@ func TreeSequential(obj Object) *TreeNode {
 		panic(fmt.Sprintf("unfinished hashing: left %v", codec.tre.groups))
 	}
 
-	fmt.Println("Leaves:")
-	for i, leaf := range codec.tre.nodes {
-		fmt.Printf("Leaf %d: %v\n", i, leaf.Value)
-	}
-	// return codec.tre.createTree()
-	return codec.tre.nodes[len(codec.tre.nodes)-2]
+	return codec.tre.createTree()[1]
+	//return codec.tre.nodes[len(codec.tre.nodes)-2]
 }
 
 // TreeConcurrent computes the SSZ Merkle tree of the object on a multiple threads.


### PR DESCRIPTION
Fixed `createTree`, the correct htr is now computed; removed Treerer methods that formerly inserted loose tree nodes upon chunk insertion, since we only build the tree from consolidated chunks.